### PR TITLE
Allow CROSS_COMPILE to be overridden on the command line

### DIFF
--- a/microwatt/Makefile
+++ b/microwatt/Makefile
@@ -1,7 +1,7 @@
 ARCH = $(shell uname -m)
 ifneq ("$(ARCH)", "ppc64")
 ifneq ("$(ARCH)", "ppc64le")
-	CROSS_COMPILE = powerpc64le-linux-gnu-
+	CROSS_COMPILE ?= powerpc64le-linux-
 endif
 endif
 

--- a/posix/Makefile
+++ b/posix/Makefile
@@ -1,7 +1,7 @@
 ARCH = $(shell uname -m)
 ifneq ("$(ARCH)", "ppc64")
 ifneq ("$(ARCH)", "ppc64le")
-	CROSS_COMPILE = powerpc64le-linux-
+	CROSS_COMPILE ?= powerpc64le-linux-
 endif
 endif
 


### PR DESCRIPTION
Also use the same compiler for both posix and microwatt backends.